### PR TITLE
Flight sim now acts on vehicle rather than be part of it

### DIFF
--- a/LRETools/vehicle.py
+++ b/LRETools/vehicle.py
@@ -35,9 +35,3 @@ class Vehicle:
     def calculateDeltaV(self):
         
         self.deltaV = self.engine.specificImpulse * self.G * log(self.wetMass / self.dryMass)
-
-    def performFlightSimulation(self, timeStep=0.1, variablesToPlot="All", showPlot=False, saveFileName="Simulation.png", plotAbsoluteValues=True):
-        
-        self.flightSimulation = flight.Flight(self.airframe.frontalArea, self.airframe.cdValues, self.airframe.machValues)
-        self.flightSimulation.flightSimulation(self.wetMass, self.propellantMass, self.engine.thrust, self.engine.specificImpulse, timeStep=timeStep, saveAbsoluteValues=plotAbsoluteValues)
-        self.flightSimulation.plotGraph(variablesToPlot=variablesToPlot, show=showPlot, fileName=saveFileName)

--- a/Sunfire.py
+++ b/Sunfire.py
@@ -1,4 +1,5 @@
 from LRETools import vehicle
+from LRETools.SubSystems.FlightSimulation.flight import Flight
 import LRETools.SubSystems.Engine.Cycle.cyclediagrams as cyclediagrams
 
 sunfire = vehicle.Vehicle("Sunfire", "Methane", "Oxygen")
@@ -13,7 +14,7 @@ sunfire.engine.findPropellantMassFlowRates()
 # Define airframe parameters
 sunfire.airframe.setMass(30)
 sunfire.airframe.setDragCharacteristics(0.11, "dragCurve.csv")
-sunfire.airframe.setTotalTankVolume(0.2)
+sunfire.airframe.setTotalTankVolume(0.03)
 
 # Define engine cycle parameters
 sunfire.engine.cycle.setFuelTank(100, 3e5)
@@ -24,7 +25,7 @@ sunfire.engine.cycle.setOxPumpEfficiency(0.7)
 sunfire.engine.cycle.setTurbineEfficiency(0.7)
 sunfire.engine.cycle.setRegenCoolingEstimate(147*5, 205900, sunfire.engine.chamberTemp, 300, 4/1e3, 400, 0.2785, 9e5)
 
-simulate = "cycle"
+simulate = "flight"
 
 if simulate == "cycle":
     # Draw cycle
@@ -37,4 +38,7 @@ elif simulate == "flight":
     # Perform flight simulation
     sunfire.calculateMasses()
     sunfire.calculateDeltaV()
-    sunfire.performFlightSimulation(timeStep=0.1, showPlot=True, variablesToPlot=["Altitude", "Velocity"])
+    
+    flightSim = Flight(sunfire)
+    flightSim.flightSimulation()
+    flightSim.plotGraph()


### PR DESCRIPTION
Flight sim code was confusingly laid out. It stood alone, and was used within a function of a vehicle object, meaning multiple variables had to be passed down through multiple functions in order to get to the flight sim code. So if an extra key variable was added to the vehicle object for the flight sim code, it would have to be added in multiple places in order to get it functional, making maintainability difficult. 

This change removes that, making the flight sim code a class that takes in a vehicle object to perform the simulation on.